### PR TITLE
Fix "cannot access private constructor" in TransferClient

### DIFF
--- a/src/aws/transfer/S3FileRequest.hx
+++ b/src/aws/transfer/S3FileRequest.hx
@@ -6,7 +6,7 @@ using neko.Lib;
 class S3FileRequest {
 	var _handle(default, null):Dynamic;
 
-	function new():Void {}
+	public function new():Void {}
 
 	public function isDone():Bool {
 		return S3FileRequest_IsDone(_handle) > 0;


### PR DESCRIPTION
This should fix one of the CI failures on the Haxelib repo:

```
C:\HaxeToolkit\haxe\lib\aws-sdk-neko/0,2,0/src/aws/transfer/TransferClient.hx:21: characters 11-34 : Cannot access private constructor of aws.transfer.UploadFileRequest
C:\HaxeToolkit\haxe\lib\aws-sdk-neko/0,2,0/src/aws/transfer/TransferClient.hx:33: characters 11-36 : Cannot access private constructor of aws.transfer.DownloadFileRequest
```