### PR TITLE
[cmake] Avoid zlib issue on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,9 @@ if (NOT EXISTS ${AWS_SDK_BUILD_DIR})
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH ${AWS_SDK_INSTALL_DIR})
-find_package(ZLIB REQUIRED)
+if (NOT WIN32)
+	find_package(ZLIB REQUIRED)
+endif()
 find_package(AWSSDK REQUIRED COMPONENTS s3 transfer)
 
 find_path(NEKO_INCLUDE_DIRS neko.h


### PR DESCRIPTION
It is not necessary to include zlib on windows.

```
CMake Error at C:/Program Files/CMake/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR)
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  C:/Program Files/CMake/share/cmake-3.31/Modules/FindZLIB.cmake:202 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:78 (find_package)


-- Configuring incomplete, errors occurred!
```

This problem was introduced in #3